### PR TITLE
[RFC] Add emacs icon on start of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a href="https://github.com/mgalgs/make-readme-markdown"><img src="https://www.gnu.org/software/emacs/images/emacs.png" alt="Emacs Logo" width="80" height="80" align="right"></a>
 ## make-readme-markdown.el
 *Convert emacs lisp documentation to markdown all day every day*
 
@@ -21,6 +22,7 @@ have to maintain two separate files that say the same thing.
 * License badge (auto-detected, see [Badges](#badges))
 * MELPA and MELPA-Stable badges (auto-detected, see [Badges](#badges))
 * Travis badge (auto-detected, see [Badges](#badges))
+* Emacs Icon
 
 ### Installation
 
@@ -181,6 +183,10 @@ Print badges for license, package repo, etc.
 
 Tries to parse a license from the comments, printing a badge for
 any license found.
+
+#### `(print-emacs-icon)`
+
+Print emacs icon to generate a fancy README.md.
 
 -----
 <div style="padding-top:15px;color: #d0d0d0;">

--- a/make-readme-markdown.el
+++ b/make-readme-markdown.el
@@ -41,6 +41,7 @@
 ;; o License badge (auto-detected, see [Badges](#badges))
 ;; o MELPA and MELPA-Stable badges (auto-detected, see [Badges](#badges))
 ;; o Travis badge (auto-detected, see [Badges](#badges))
+;; o Emacs Icon
 
 ;;; Installation:
 ;;
@@ -384,6 +385,20 @@ any license found."
   (print-license-badge lines)
   (print-status-badges lines))
 
+(defun print-emacs-icon ()
+  "Print emacs icon to generate a fancy README.md."
+  (let* ((package-url (plist-get file-headers 'URL))
+         (logo-url "<img src=\"https://www.gnu.org/software/emacs/images/emacs.png\" alt=\"Emacs Logo\" width=\"80\" height=\"80\" align=\"right\">"))
+    (if package-url
+        (progn
+          (message "Adding emacs icon with URL: %s" package-url)
+          (princ (format "<a href=\"%s\">%s</a>\n"
+                         package-url
+                         logo-url)))
+        (message "Adding emacs icon without URL")
+        (princ (format "%s\n"
+                       logo-url)))))
+
 (defvar file-headers)
 
 (let* ((line nil)
@@ -395,6 +410,9 @@ any license found."
        (code (concat "(progn\n" (mapconcat 'identity lines "\n") "\n)")))
 
   (setq file-headers (get-file-headers lines))
+
+  ;; Add Emacs icon to README.md first
+  (print-emacs-icon)
 
   ;; The first line should be like ";;; lol.el --- does stuff".
   (while (if (string-match "^;;;" (car lines))


### PR DESCRIPTION
Add emacs icon on generated README.md.

I found lots of emacs project's README.md has the emacs icon, it will be nice to add it.

This PR will make the README.md looks like:

![e](https://user-images.githubusercontent.com/39703/63569796-68d03380-c5ad-11e9-99e1-ecabcc80d454.png)

instead of:

![g](https://user-images.githubusercontent.com/39703/63569917-e431e500-c5ad-11e9-992c-6f4579eddf19.png)

